### PR TITLE
Adding copybutton

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ release = '0.1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_copybutton',
     'sphinxemoji.sphinxemoji',
     'sphinx_rtd_theme',
     'sphinx_togglebutton'
@@ -185,3 +186,12 @@ epub_exclude_files = ['search.html']
 # To allow css styling
 def setup(app):
     app.add_css_file('custom.css')
+    
+# -- Options for sphinx-copybutton -------------------------------------------
+
+# If your code examples include Python prompts like >>> or ..., this tells the copy button to ignore them when copying.
+copybutton_prompt_text = r">>> |\.\.\. "
+
+# Treat the prompt text as a regular expression so both >>> and ... are matched.
+copybutton_prompt_is_regexp = True
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinxemoji
 sphinx-rtd-theme
 sphinx-togglebutton
+sphinx-copybutton

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sphinx-rtd-theme
 sphinx-fontawesome
 sphinxemoji
 sphinx-togglebutton
+sphinx-copybutton


### PR DESCRIPTION
This is a very minor update suggestion.
While reviewing the tutorial, I noticed that some sections contain large blocks of code. In those cases, it might be easier for users to copy the code directly rather than typing it all out. Of course, I’ll still include coding exercises and problems for them to solve independently, but allowing them to copy longer snippets could be helpful.
I’m considering enabling a "copy" button for code blocks (it only appears when you hover over the code box). It automatically removes prompts like >>> if present and copies the entire block cleanly.
To enable this, we’d need to update the conf.py file and the requirements to include the sphinx-copybutton extension.